### PR TITLE
fix: add associated domain entry without mode=developer param

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,7 +22,7 @@
       "config": {
         "usesNonExemptEncryption": false
       },
-      "associatedDomains": ["webcredentials:api.useliquid.xyz?mode=developer"]
+      "associatedDomains": ["webcredentials:api.useliquid.xyz?mode=developer", "webcredentials:api.useliquid.xyz"]
     },
     "android": {
       "adaptiveIcon": {


### PR DESCRIPTION
This PR fixes the Face ID / Passkeys not working on physical devices.

Tested on iPhone 12 mini and iPhone 14 Pro Max.

| iPhone 12 mini | iPhone 14 Pro Max |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/1bd62271-775c-40c8-859f-9a6a1c8ee930" /> | <video src="https://github.com/user-attachments/assets/b06ec179-7198-4d08-8046-7390754d4054" /> |





