### PR TITLE
fix: passkey integration

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,12 +22,7 @@
       "config": {
         "usesNonExemptEncryption": false
       },
-      "associatedDomains": [
-        "webcredentials:api.useliquid.xyz?mode=developer",
-        "webcredentials:api.useliquid.xyz",
-        "webcredentials:development.useliquid.xyz",
-        "webcredentials:xyz.useliquid.liquid"
-      ]
+      "associatedDomains": ["webcredentials:api.useliquid.xyz", "webcredentials:development.useliquid.xyz"]
     },
     "android": {
       "adaptiveIcon": {

--- a/constants/env.ts
+++ b/constants/env.ts
@@ -9,8 +9,15 @@ export const rpId = 'api.useliquid.xyz';
 export const smartAccountInfoKey = 'SMART_ACCOUNT_INFO';
 
 export const privyAppId = process.env.EXPO_PUBLIC_PRIVY_APP_ID as string;
-export const privyClientId = process.env.EXPO_PUBLIC_PRIVY_CLIENT_ID;
+export const privyClientId = process.env.EXPO_PUBLIC_PRIVY_CLIENT_ID as string;
 
 if (!privyAppId || !privyClientId) {
-  throw new Error('Privy App ID and Client ID are required');
+  throw new Error('EXPO_PUBLIC_PRIVY_APP_ID and EXPO_PUBLIC_PRIVY_CLIENT_ID are required');
+}
+
+export const apiUrl = process.env.EXPO_PUBLIC_API_URL as string;
+export const apiKey = process.env.EXPO_PUBLIC_API_KEY as string;
+
+if (!apiUrl || !apiKey) {
+  throw new Error('EXPO_PUBLIC_API_URL and EXPO_PUBLIC_API_KEY are required');
 }

--- a/init/api.ts
+++ b/init/api.ts
@@ -1,26 +1,14 @@
 import { PoolResponse } from '@/store/pools/types';
-import {
-  CreatePassKeyCredentialOptions,
-  Address,
-  PasskeyRegistrationResult,
-  PoolType,
-  VerifyRegistration,
-  AuthCredentialOptions,
-} from './types';
+import { CreatePassKeyCredentialOptions, Address, PoolType, VerifyRegistration, AuthCredentialOptions } from './types';
 import { AuthenticationResponseJSON } from 'react-native-passkeys/build/ReactNativePasskeys.types';
+
+import { apiKey, apiUrl } from '@/constants/env';
 
 class LiquidAPI {
   private apiBaseUrl: string;
   private apiKey: string;
 
   constructor() {
-    const apiUrl = process.env.EXPO_PUBLIC_X_API_URL;
-    const apiKey = process.env.EXPO_PUBLIC_X_API_KEY;
-
-    if (!apiUrl || !apiKey) {
-      throw new Error('EXPO_PUBLIC_API_URL or EXPO_PUBLIC_API_KEY is not set');
-    }
-
     this.apiBaseUrl = apiUrl;
     this.apiKey = apiKey;
   }


### PR DESCRIPTION
What broke it:

- Apple team ID changed from `5HJRLLGXT3` to `9S3LU9BPRR`
- Bundle ID changed from `com.liquid.supermigrate` to `xyz.useliquid.liquid`

Yet somehow the AASA file deployed https://api.useliquid.xyz/.well-known/apple-app-site-association to contains this:

```json
{"applinks":{},"webcredentials":{"apps":["6736911454.com.liquid.supermigrate"]},"appclips":{}}
```

https://github.com/user-attachments/assets/4acebf75-e9ea-411d-81f6-d97f5cce9359


