### PR TITLE
fix: tap to go to next and prev / fix progress pause on press next or prev

### DIFF
--- a/app/(onboarding)/_layout.tsx
+++ b/app/(onboarding)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { StyleSheet, Dimensions, Platform, View, StatusBar as RNStatusBar, Text, Pressable } from 'react-native';
+import { StyleSheet, Dimensions, Platform, View, StatusBar as RNStatusBar, Pressable } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { StatusBar } from 'expo-status-bar';
 

--- a/app/(onboarding)/_layout.tsx
+++ b/app/(onboarding)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { StyleSheet, Dimensions, Platform, View, StatusBar as RNStatusBar } from 'react-native';
+import { StyleSheet, Dimensions, Platform, View, StatusBar as RNStatusBar, Text, Pressable } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { StatusBar } from 'expo-status-bar';
 
@@ -52,6 +52,17 @@ export default function OnboardingTabLayout() {
         }
         setFinished(true);
         setIsPaused(true);
+        break;
+    }
+  };
+
+  const navigateToPreviousScreen = () => {
+    switch (pathname) {
+      case '/step2':
+        router.push('/(onboarding)/step1');
+        break;
+      case '/step3':
+        router.push('/(onboarding)/step2');
         break;
     }
   };
@@ -130,6 +141,23 @@ export default function OnboardingTabLayout() {
         />
       </Tab.Navigator>
 
+      <Pressable
+        onPress={() => {
+          if (currentStep > 0) {
+            navigateToPreviousScreen();
+          }
+        }}
+        style={styles.prev}
+      />
+      <Pressable
+        onPress={() => {
+          if (currentStep < 2) {
+            navigateToNextScreen();
+          }
+        }}
+        style={styles.next}
+      />
+
       <View style={styles.action}>
         <LQDButton onPress={() => router.replace('/(signup)')} title="Let's go!" />
       </View>
@@ -154,5 +182,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingBottom: Platform.OS === 'ios' ? 33 : 16,
     width: Dimensions.get('window').width,
+  },
+  prev: {
+    flex: 1,
+    position: 'absolute',
+    height: Dimensions.get('window').height,
+    left: 0,
+    width: 65,
+  },
+  next: {
+    flex: 1,
+    position: 'absolute',
+    height: Dimensions.get('window').height,
+    right: 0,
+    width: 65,
   },
 });

--- a/components/onboarding/indicator/index.tsx
+++ b/components/onboarding/indicator/index.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
 import Animated, { useSharedValue, withTiming, useAnimatedStyle, Easing } from 'react-native-reanimated';
-
 import { adjustFontSizeForIOS } from '@/utils/helpers';
 
 const LQDOnboardingIndicator = ({ currentStep, isPaused, timer, totalSteps, finished, togglePause }: ILQDOnboardingIndicator) => {
   const actions = [require('../../../assets/images/pause.png'), require('../../../assets/images/play.png')];
+  const [progressValues, setProgressValues] = useState<number[]>(new Array(totalSteps).fill(0)); // Track progress for each step
 
   const animatedWidthStyle = (index: number) => {
-    const progress = useSharedValue(0);
+    const progress = useSharedValue(progressValues[index]); // Use the progress for the specific step
 
     useEffect(() => {
       if (index === currentStep && !isPaused) {
@@ -21,21 +21,25 @@ const LQDOnboardingIndicator = ({ currentStep, isPaused, timer, totalSteps, fini
           });
         }
       }
+
+      if (index === currentStep && progress.value !== progressValues[index]) {
+        setProgressValues((prevValues) => {
+          const newValues = [...prevValues];
+          newValues[index] = progress.value;
+          return newValues;
+        });
+      }
+
+      if (index < currentStep) {
+        progress.value = 1;
+      } else if (index > currentStep) {
+        progress.value = 0;
+      }
     }, [timer, isPaused, currentStep, finished]);
 
-    return useAnimatedStyle(() => {
-      if (index === 0 && currentStep === 0) {
-        return { width: `${progress.value * 100}%` };
-      } else if (index === 0 && currentStep > 0) {
-        return { width: '100%' };
-      } else if (index === currentStep) {
-        return { width: `${progress.value * 100}%` };
-      } else if (index < currentStep) {
-        return { width: '100%' };
-      } else {
-        return { width: '0%' };
-      }
-    });
+    return useAnimatedStyle(() => ({
+      width: `${progress.value * 100}%`,
+    }));
   };
 
   return (

--- a/components/onboarding/indicator/index.tsx
+++ b/components/onboarding/indicator/index.tsx
@@ -5,10 +5,10 @@ import { adjustFontSizeForIOS } from '@/utils/helpers';
 
 const LQDOnboardingIndicator = ({ currentStep, isPaused, timer, totalSteps, finished, togglePause }: ILQDOnboardingIndicator) => {
   const actions = [require('../../../assets/images/pause.png'), require('../../../assets/images/play.png')];
-  const [progressValues, setProgressValues] = useState<number[]>(new Array(totalSteps).fill(0)); // Track progress for each step
+  const [progressValues, setProgressValues] = useState<number[]>(new Array(totalSteps).fill(0));
 
   const animatedWidthStyle = (index: number) => {
-    const progress = useSharedValue(progressValues[index]); // Use the progress for the specific step
+    const progress = useSharedValue(progressValues[index]);
 
     useEffect(() => {
       if (index === currentStep && !isPaused) {


### PR DESCRIPTION
- user can now click the right and left edge to the next and prev slide
- noticed the progress pausing on each step when a user slides or clicks to go next, this has been fixed.

https://github.com/user-attachments/assets/a9e3a903-b3bf-4791-b5cb-e0cd25393fd1