### PR TITLE
Fix/toast resend otp

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,12 +8,14 @@ import '@/init/client';
 import '@/init/api';
 
 import { AllProviders } from '@/providers';
-import { LQDStackHeader } from '@/components';
+import { LQDStackHeader, LQToast } from '@/components';
+import { View } from 'react-native';
 
 export default function RootLayout() {
   return (
     <AllProviders>
       <RootStack />
+      <LQToast />
     </AllProviders>
   );
 }

--- a/assets/icons/close-toast-icon.tsx
+++ b/assets/icons/close-toast-icon.tsx
@@ -1,0 +1,11 @@
+import Svg, { Path } from 'react-native-svg';
+
+const CloseToastIcon = () => (
+  <Svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <Path
+      d="M5.00005 3.93955L8.71255 0.227051L9.77305 1.28755L6.06055 5.00005L9.77305 8.71255L8.71255 9.77305L5.00005 6.06055L1.28755 9.77305L0.227051 8.71255L3.93955 5.00005L0.227051 1.28755L1.28755 0.227051L5.00005 3.93955Z"
+      fill="#525866"
+    />
+  </Svg>
+);
+export default CloseToastIcon;

--- a/assets/icons/index.ts
+++ b/assets/icons/index.ts
@@ -51,10 +51,14 @@ import SupportIcon from './support-icon';
 import XIcon from './x-ixon';
 import DiscordIcon from './discord-icon';
 import SearchEmptyStateIcon from './search-empty-state-icon';
+import CloseToastIcon from './close-toast-icon';
+import ToastVarintIcon from './toast-varient-icon';
 
 export {
   SwatchIcon,
   SearchEmptyStateIcon,
+  CloseToastIcon,
+  ToastVarintIcon,
   ChartIcon,
   ShieldTickIcon,
   MoneysIcon,

--- a/assets/icons/search-empty-state-icon.tsx
+++ b/assets/icons/search-empty-state-icon.tsx
@@ -1,6 +1,6 @@
 import Svg, { Path, Rect } from 'react-native-svg';
 
-const SearchEmptyStateIcon = ({ fill = '#fff', height = 14, width = 14 }: IconProps) => (
+const SearchEmptyStateIcon = () => (
   <Svg width="41" height="40" viewBox="0 0 41 40" fill="none" xmlns="http://www.w3.org/2000/svg">
     <Rect x="0.5" width="40" height="40" rx="12" fill="#334155" />
     <Path d="M17.5 19.7H22.5" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />

--- a/assets/icons/toast-varient-icon.tsx
+++ b/assets/icons/toast-varient-icon.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+const ToastVarintIcon = ({ variant }: { variant: string }) => {
+  switch (variant) {
+    case 'success':
+      return (
+        <Svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <Path
+            d="M10 17.5C5.85775 17.5 2.5 14.1423 2.5 10C2.5 5.85775 5.85775 2.5 10 2.5C14.1423 2.5 17.5 5.85775 17.5 10C17.5 14.1423 14.1423 17.5 10 17.5ZM9.25225 13L14.5548 7.69675L13.4943 6.63625L9.25225 10.879L7.1305 8.75725L6.07 9.81775L9.25225 13Z"
+            fill="#38C793"
+          />
+        </Svg>
+      );
+    case 'error':
+      return (
+        <Svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <Path
+            d="M10 17.5C5.85775 17.5 2.5 14.1423 2.5 10C2.5 5.85775 5.85775 2.5 10 2.5C14.1423 2.5 17.5 5.85775 17.5 10C17.5 14.1423 14.1423 17.5 10 17.5ZM9.25 12.25V13.75H10.75V12.25H9.25ZM9.25 6.25V10.75H10.75V6.25H9.25Z"
+            fill="#DF1C41"
+          />
+        </Svg>
+      );
+    default:
+      return null;
+  }
+};
+
+export default ToastVarintIcon;

--- a/components/enter-email/index.tsx
+++ b/components/enter-email/index.tsx
@@ -9,9 +9,11 @@ import useSystemFunctions from '@/hooks/useSystemFunctions';
 import { adjustFontSizeForIOS, emailIsValid } from '@/utils/helpers';
 import { useSmartAccountActions } from '@/store/smartAccount/actions';
 import api from '@/init/api';
+import { useToastActions } from '@/store/toast/actions';
 
 const EnterEmail = ({ isSignup }: Props) => {
   const { router } = useSystemFunctions();
+  const { showToast } = useToastActions();
   const { updateRegistrationOptions } = useSmartAccountActions();
   const { logout } = usePrivy();
   const { sendCode } = useLoginWithEmail({
@@ -119,7 +121,17 @@ const EnterEmail = ({ isSignup }: Props) => {
               </View>
             )}
 
-            <LQDButton title="Continue" onPress={onSubmit} variant="secondary" disabled={!isValid} loading={loading} />
+            <LQDButton
+              title="Continue ddd"
+              onPress={() =>
+                showToast({
+                  title: 'Success!',
+                  description: 'Your operation was successful.',
+                  variant: 'success',
+                })
+              }
+              variant="secondary"
+            />
 
             {isSignup && (
               <TouchableOpacity onPress={() => router.push('/(login)')} style={styles.actionWrapper}>

--- a/components/enter-email/index.tsx
+++ b/components/enter-email/index.tsx
@@ -9,11 +9,9 @@ import useSystemFunctions from '@/hooks/useSystemFunctions';
 import { adjustFontSizeForIOS, emailIsValid } from '@/utils/helpers';
 import { useSmartAccountActions } from '@/store/smartAccount/actions';
 import api from '@/init/api';
-import { useToastActions } from '@/store/toast/actions';
 
 const EnterEmail = ({ isSignup }: Props) => {
   const { router } = useSystemFunctions();
-  const { showToast } = useToastActions();
   const { updateRegistrationOptions } = useSmartAccountActions();
   const { logout } = usePrivy();
   const { sendCode } = useLoginWithEmail({
@@ -121,17 +119,7 @@ const EnterEmail = ({ isSignup }: Props) => {
               </View>
             )}
 
-            <LQDButton
-              title="Continue ddd"
-              onPress={() =>
-                showToast({
-                  title: 'Success!',
-                  description: 'Your operation was successful.',
-                  variant: 'success',
-                })
-              }
-              variant="secondary"
-            />
+            <LQDButton title="Continue" onPress={onSubmit} variant="secondary" disabled={!isValid} loading={loading} />
 
             {isSignup && (
               <TouchableOpacity onPress={() => router.push('/(login)')} style={styles.actionWrapper}>

--- a/components/index.ts
+++ b/components/index.ts
@@ -18,6 +18,7 @@ import SearchUI from './search-ui';
 import LQDPoolImages from './pool-images';
 import LQDTokenImage from './pool-images/token-image';
 import LQShrimeLoader from './loader';
+import LQToast from './toast';
 
 export {
   LQDButton,
@@ -25,6 +26,7 @@ export {
   LQDNavigation,
   LQDInput,
   LQDSearch,
+  LQToast,
   LQDScrollView,
   LQDStackHeader,
   LQDPoolPairCard,

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -9,7 +9,13 @@ const LQToast = () => {
   const { hideToast } = useToastActions();
 
   const { title, description, variant, isVisible } = toast;
-  const icon = variant === 'success' ? <ToastVarintIcon variant="success" /> : <ToastVarintIcon variant="error" />;
+
+  const iconsMap = {
+    success: <ToastVarintIcon variant="success" />,
+    error: <ToastVarintIcon variant="error" />,
+  };
+
+  const icon = iconsMap[variant] || null;
 
   const slideAnim = useRef(new Animated.Value(-100)).current;
 

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -1,40 +1,47 @@
-// import { Animated, Text } from 'react-native';
-// import { ILQToast } from './types';
-
-// const LQToast = ({ title, description, variant }: ILQToast) => {
-//   return (
-//     <Animated.View>
-//       <Text>{title}</Text>
-//       <Text>{description}</Text>
-//     </Animated.View>
-//   );
-// };
-
-// export default LQToast;
-
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Animated, Text, StyleSheet, View, TouchableOpacity } from 'react-native';
 import useSystemFunctions from '@/hooks/useSystemFunctions';
 import { useToastActions } from '@/store/toast/actions';
+import { CloseToastIcon, ToastVarintIcon } from '@/assets/icons';
 
 const LQToast = () => {
   const { toast } = useSystemFunctions();
   const { hideToast } = useToastActions();
 
   const { title, description, variant, isVisible } = toast;
+  const icon = variant === 'success' ? <ToastVarintIcon variant="success" /> : <ToastVarintIcon variant="error" />;
+
+  const slideAnim = useRef(new Animated.Value(-100)).current;
+
+  useEffect(() => {
+    if (isVisible) {
+      Animated.timing(slideAnim, {
+        toValue: 60,
+        duration: 300,
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(slideAnim, {
+        toValue: -100,
+        duration: 300,
+        useNativeDriver: true,
+      }).start();
+    }
+  }, [isVisible, slideAnim]);
 
   const handleDismiss = () => {
     hideToast();
   };
 
-  if (!isVisible) return null;
-
   return (
-    <Animated.View style={[styles.toastContainer, styles[variant]]}>
-      <Text style={styles.title}>{title}</Text>
-      <Text style={styles.description}>{description}</Text>
-      <TouchableOpacity onPress={handleDismiss}>
-        <Text style={styles.dismissText}>Dismiss</Text>
+    <Animated.View style={[styles.toastContainer, styles[variant], { transform: [{ translateY: slideAnim }] }]}>
+      {icon}
+      <View style={{ flex: 1, gap: 3 }}>
+        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.description}>{description}</Text>
+      </View>
+      <TouchableOpacity style={{ marginRight: 3 }} onPress={handleDismiss}>
+        <CloseToastIcon />
       </TouchableOpacity>
     </Animated.View>
   );
@@ -45,18 +52,18 @@ export default LQToast;
 const styles = StyleSheet.create({
   toastContainer: {
     position: 'absolute',
-    top: 50,
-    padding: 10,
-    right: 0,
-    left: 0,
+    paddingHorizontal: 10,
+    paddingVertical: 13,
+    right: 20,
+    left: 20,
     borderRadius: 5,
-    backgroundColor: '#333',
     zIndex: 23456789,
+    flexDirection: 'row',
+    gap: 10,
+    backgroundColor: 'red',
   },
-  success: { backgroundColor: 'green' },
-  error: { backgroundColor: 'red' },
-  info: { backgroundColor: 'blue' },
-  title: { fontSize: 16, fontWeight: 'bold', color: '#fff' },
-  description: { fontSize: 14, color: '#fff' },
-  dismissText: { fontSize: 12, color: 'yellow', marginTop: 5 },
+  success: { backgroundColor: '#EFFAF6', top: 10 },
+  error: { backgroundColor: '#FDEDF0', top: 10 },
+  title: { fontSize: 15, fontFamily: 'AeonikMedium', fontWeight: '700', color: '#0A0D14' },
+  description: { color: '#64748B', fontSize: 15, fontFamily: 'AeonikRegular', fontWeight: '500' },
 });

--- a/components/toast/index.tsx
+++ b/components/toast/index.tsx
@@ -1,0 +1,62 @@
+// import { Animated, Text } from 'react-native';
+// import { ILQToast } from './types';
+
+// const LQToast = ({ title, description, variant }: ILQToast) => {
+//   return (
+//     <Animated.View>
+//       <Text>{title}</Text>
+//       <Text>{description}</Text>
+//     </Animated.View>
+//   );
+// };
+
+// export default LQToast;
+
+import React from 'react';
+import { Animated, Text, StyleSheet, View, TouchableOpacity } from 'react-native';
+import useSystemFunctions from '@/hooks/useSystemFunctions';
+import { useToastActions } from '@/store/toast/actions';
+
+const LQToast = () => {
+  const { toast } = useSystemFunctions();
+  const { hideToast } = useToastActions();
+
+  const { title, description, variant, isVisible } = toast;
+
+  const handleDismiss = () => {
+    hideToast();
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <Animated.View style={[styles.toastContainer, styles[variant]]}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.description}>{description}</Text>
+      <TouchableOpacity onPress={handleDismiss}>
+        <Text style={styles.dismissText}>Dismiss</Text>
+      </TouchableOpacity>
+    </Animated.View>
+  );
+};
+
+export default LQToast;
+
+const styles = StyleSheet.create({
+  toastContainer: {
+    position: 'absolute',
+    top: 50,
+    padding: 10,
+    right: 0,
+    left: 0,
+    borderRadius: 5,
+    backgroundColor: '#333',
+    zIndex: 23456789,
+  },
+  success: { backgroundColor: 'green' },
+  error: { backgroundColor: 'red' },
+  info: { backgroundColor: 'blue' },
+  title: { fontSize: 16, fontWeight: 'bold', color: '#fff' },
+  description: { fontSize: 14, color: '#fff' },
+  dismissText: { fontSize: 12, color: 'yellow', marginTop: 5 },
+});

--- a/components/toast/types.ts
+++ b/components/toast/types.ts
@@ -1,0 +1,7 @@
+interface ILQToast {
+  title: string;
+  description: string;
+  variant: 'error' | 'success';
+}
+
+export type { ILQToast };

--- a/components/verify-email/index.tsx
+++ b/components/verify-email/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, Platform, StatusBar as RNStatusBar, ViewStyle, Alert, Touchable, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, Platform, StatusBar as RNStatusBar, ViewStyle, TouchableOpacity } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { OtpInput } from 'react-native-otp-entry';
 import { useLoginWithEmail } from '@privy-io/expo';
@@ -9,16 +9,23 @@ import LQDKeyboardWrapper from '@/components/keyboard-wrapper';
 import useSystemFunctions from '@/hooks/useSystemFunctions';
 import { adjustFontSizeForIOS } from '@/utils/helpers';
 import { useSmartAccountActions } from '@/store/smartAccount/actions';
+import { useToastActions } from '@/store/toast/actions';
 
 const VerifyEmail = ({ email, isSignup }: { email: string; isSignup?: boolean }) => {
   const { router } = useSystemFunctions();
   const { login } = useSmartAccountActions();
+  const { showToast } = useToastActions();
 
   const { loginWithCode, sendCode } = useLoginWithEmail({
     onError: (error) => {
       console.log('error', error.message);
       setLoading(false);
-      Alert.alert('An error occurred. Please check your email and try again.');
+
+      showToast({
+        title: 'Error',
+        description: 'An error occurred. Please check your email and try again.',
+        variant: 'error',
+      });
     },
     onLoginSuccess: async () => {
       if (isSignup) {
@@ -28,6 +35,11 @@ const VerifyEmail = ({ email, isSignup }: { email: string; isSignup?: boolean })
     },
     onSendCodeSuccess: () => {
       setResendDisabled(true);
+      showToast({
+        title: 'OTP sent.',
+        description: 'An OTP has been sent. Please check your email',
+        variant: 'success',
+      });
       setCountdownTimer(30);
       startCountdown();
     },
@@ -58,9 +70,12 @@ const VerifyEmail = ({ email, isSignup }: { email: string; isSignup?: boolean })
       if (countdownTimer > 0 || resendDisabled) return;
       setResendDisabled(true);
       await sendCode({ email });
-      Alert.alert('An OTP has been sent to your email. Please check your inbox.');
     } catch (error) {
-      Alert.alert('An error occurred. Please check your email and try again.');
+      showToast({
+        title: 'Error',
+        description: 'An error occurred. Please check your email and try again.',
+        variant: 'error',
+      });
     } finally {
       setResendDisabled(false);
     }

--- a/components/verify-email/index.tsx
+++ b/components/verify-email/index.tsx
@@ -58,9 +58,9 @@ const VerifyEmail = ({ email, isSignup }: { email: string; isSignup?: boolean })
       if (countdownTimer > 0 || resendDisabled) return;
       setResendDisabled(true);
       await sendCode({ email });
+      Alert.alert('An OTP has been sent to your email. Please check your inbox.');
     } catch (error) {
       Alert.alert('An error occurred. Please check your email and try again.');
-      setResendDisabled(false);
     } finally {
       setResendDisabled(false);
     }

--- a/hooks/useSystemFunctions.tsx
+++ b/hooks/useSystemFunctions.tsx
@@ -19,6 +19,7 @@ const useSystemFunctions = () => {
   const smartAccountState = useAppSelector((state) => state.smartAccount);
   const poolsState = useAppSelector((state) => state.pools);
   const accountState = useAppSelector((state) => state.account);
+  const toast = useAppSelector((state) => state.toast);
 
   return {
     dispatch,
@@ -32,6 +33,7 @@ const useSystemFunctions = () => {
     smartAccountState,
     poolsState,
     accountState,
+    toast,
   };
 };
 

--- a/store/index.ts
+++ b/store/index.ts
@@ -8,6 +8,7 @@ import appReducer from './app';
 import smartAccountReducer from './smartAccount';
 import poolReducer from './pools';
 import accountReducer from './account';
+import toastReducer from './toast';
 
 export interface CallbackProps {
   onSuccess?: Function;
@@ -20,6 +21,7 @@ const rootReducer = combineReducers({
   smartAccount: smartAccountReducer,
   pools: poolReducer,
   account: accountReducer,
+  toast: toastReducer,
 });
 
 const persistConfig = {
@@ -35,6 +37,7 @@ export const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       serializableCheck: false,
+      immutableCheck: false,
       // serializableCheck: {
       //   // Ignore redux-persist actions
       //   ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],

--- a/store/toast/actions.ts
+++ b/store/toast/actions.ts
@@ -1,0 +1,24 @@
+import { useDispatch } from 'react-redux';
+import { hideToast, showToast } from './index';
+import { Toast } from './types';
+
+export function useToastActions() {
+  const dispatch = useDispatch();
+
+  const showToastAction = ({ title, description, variant }: Toast) => {
+    dispatch(showToast({ title, description, variant }));
+
+    setTimeout(() => {
+      dispatch(hideToast());
+    }, 4000);
+  };
+
+  const hideToastAction = () => {
+    dispatch(hideToast());
+  };
+
+  return {
+    showToast: showToastAction,
+    hideToast: hideToastAction,
+  };
+}

--- a/store/toast/index.ts
+++ b/store/toast/index.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Toast } from './types';
+
+const initialState: Toast = {
+  title: '',
+  description: '',
+  variant: 'success',
+  isVisible: false,
+};
+
+export const toastReducer = createSlice({
+  name: 'toast',
+  initialState,
+  reducers: {
+    showToast: (state, action: PayloadAction<Toast>) => {
+      const { title, description, variant } = action.payload;
+      state.title = title;
+      state.description = description;
+      state.variant = variant;
+      state.isVisible = true;
+    },
+
+    hideToast: (state) => {
+      state.isVisible = false;
+      state.title = '';
+      state.description = '';
+    },
+  },
+});
+
+export const { showToast, hideToast } = toastReducer.actions;
+
+export default toastReducer.reducer;

--- a/store/toast/types.ts
+++ b/store/toast/types.ts
@@ -1,0 +1,6 @@
+export type Toast = {
+  title: string;
+  description: string;
+  variant: 'success' | 'error' | 'info';
+  isVisible?: boolean;
+};

--- a/store/toast/types.ts
+++ b/store/toast/types.ts
@@ -1,6 +1,6 @@
 export type Toast = {
   title: string;
   description: string;
-  variant: 'success' | 'error' | 'info';
+  variant: 'success' | 'error';
   isVisible?: boolean;
 };


### PR DESCRIPTION
1.  built a toast component that takes (title, description and variant) as props
2. imported this component foot file to make it accessible globally 
3. added a toast reduce and action folder to manage the toast state seperately


Note:
you can find the usage of showToast in the verify email screen

https://github.com/user-attachments/assets/1517f7b1-0700-42fa-8f4e-e89b82114361

