### PR TITLE
docs: Clarified the Dependency Installation Command in Step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 2. Install dependencies:
 
    ```bash
-   yarn i
+   yarn install
    ```
 
 3. Setup your `.env` file based on `.env.example`. Make sure you have a valid Liquid API key.


### PR DESCRIPTION
**Description:**

In Step 2 of the setup instructions, the command for installing dependencies was listed as `yarn i`. While this is a shorthand for `yarn install`, it might not be immediately clear to all users, especially those who are less familiar with Yarn. 

To improve clarity, the command has been updated to `yarn install`, ensuring the instructions are more intuitive and accessible to everyone.

This small change should help prevent confusion and make the setup process smoother for users at all experience levels.